### PR TITLE
Add cadastral map viewer example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Carte cadastrale</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" integrity="sha512-sA+e2YvcwqLCzGYoRGdk+8TBE4BOIcmowPdcOm16uVx7lpKknj1yxAsSUMVafKBO2OUdMvGllNk0sLlfLlh2Tg==" crossorigin="" />
+</head>
+<body>
+  <header>
+    <h1>Recherche d'adresse cadastrale</h1>
+    <form id="searchForm">
+      <input id="addressInput" type="text" placeholder="Entrez une adresse" required>
+      <button type="submit">Afficher</button>
+    </form>
+  </header>
+  <div id="map"></div>
+
+  <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js" integrity="sha512-kZ5j6tblySjXkaW1XHlzTH0jzZMfjNV8iPBUFeZVt8bDSHPsuacFZWdhLxF3/sZSGElgZpyzNlqz5IPS2rF8Rg==" crossorigin=""></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,55 @@
+// Carte interactive Leaflet
+const map = L.map('map').setView([48.8588897, 2.320041], 13);
+
+// Fond de carte OpenStreetMap
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 20,
+  attribution: '&copy; OpenStreetMap'
+}).addTo(map);
+
+// Couche des parcelles cadastrales (source data.gouv.fr)
+const cadastre = L.tileLayer('https://cadastre.openstreetmap.fr/tiles/parcelles/{z}/{x}/{y}.png', {
+  maxZoom: 20,
+  opacity: 0.7,
+  attribution: '&copy; Cadastre'
+}).addTo(map);
+
+const form = document.getElementById('searchForm');
+const input = document.getElementById('addressInput');
+
+// Recherche d'adresse et affichage de la parcelle correspondante
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const query = encodeURIComponent(input.value);
+  const url = `https://api-adresse.data.gouv.fr/search/?q=${query}&limit=1`;
+
+  try {
+    const resp = await fetch(url);
+    const data = await resp.json();
+    if (!data.features.length) {
+      alert('Adresse introuvable');
+      return;
+    }
+    const [lng, lat] = data.features[0].geometry.coordinates;
+    const label = data.features[0].properties.label;
+
+    map.setView([lat, lng], 18);
+    L.marker([lat, lng]).addTo(map).bindPopup(label).openPopup();
+
+    // Récupération de la parcelle contenant le point
+    const parcelUrl = `https://apicarto.ign.fr/api/cadastre/parcelle?lat=${lat}&lon=${lng}`;
+    const pResp = await fetch(parcelUrl);
+    const pData = await pResp.json();
+    if (pData.features && pData.features.length) {
+      const parcel = pData.features[0];
+      const ref = parcel.properties.id;
+      const geom = L.geoJSON(parcel, {
+        style: { color: '#ff0000', weight: 2 }
+      }).addTo(map);
+      geom.bindPopup(`Parcelle : ${ref}`).openPopup();
+    }
+  } catch (err) {
+    console.error(err);
+    alert('Erreur lors de la recherche');
+  }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,50 @@
+html, body {
+  height: 100%;
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+header {
+  background: #f0f0f0;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#searchForm {
+  display: flex;
+  width: 100%;
+  max-width: 500px;
+}
+
+#searchForm input {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px 0 0 4px;
+}
+
+#searchForm button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: #4caf50;
+  color: white;
+  border-radius: 0 4px 4px 0;
+  cursor: pointer;
+}
+
+#map {
+  height: calc(100% - 100px);
+}
+
+@media (max-width: 600px) {
+  #searchForm {
+    flex-direction: column;
+  }
+  #searchForm input,
+  #searchForm button {
+    border-radius: 4px;
+    margin: 2px 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive HTML page for cadastral map search
- style page with simple CSS
- implement map logic in JavaScript using Leaflet and public APIs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867ec3d758c83319d952a8471e1a33e